### PR TITLE
Bump vagrant version to stable one

### DIFF
--- a/vagrant-dns.gemspec
+++ b/vagrant-dns.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Vagrant::Dns::VERSION
 
-  gem.add_dependency "vagrant"
+  gem.add_dependency "vagrant", "~> 1.0"
   gem.add_dependency "daemons"
   gem.add_dependency "rubydns", "~> 0.5.3"
 end


### PR DESCRIPTION
This fixes #8 and possible other issues.
Vagrant supports plugins since 0.6, but I think it's safe to request ~> 1.0 one
