### PR TITLE
Allow register_patterns! to work when no private networks are specified

### DIFF
--- a/lib/vagrant-dns/configurator.rb
+++ b/lib/vagrant-dns/configurator.rb
@@ -41,7 +41,7 @@ module VagrantDNS
           network = nw if nw.first == :private_network
         end
 
-        if network
+        if ! network.empty?
           ip     = network.last[:ip]
         else
           ip     = '127.0.0.1'


### PR DESCRIPTION
Fixes an `if` statement to make an explicit check for emptiness.

Seems related to #19.
