### PR TITLE
fix issue when private_network is associated with dhcp type

### DIFF
--- a/lib/vagrant-dns/configurator.rb
+++ b/lib/vagrant-dns/configurator.rb
@@ -38,7 +38,7 @@ module VagrantDNS
         networks = opts[:networks]
         network = {}
         networks.each do |nw|
-          network = nw if nw.first == :private_network
+          network = nw if nw.first == :private_network && nw.last[:type] != 'dhcp'
         end
 
         if ! network.empty?


### PR DESCRIPTION
In the Vagrantfile, when the network setting is defined as `config.vm.network "private_network", type: "dhcp"` the plugin will not work and the vm machine is not accessible using the tld.

Is is referenced in
- issue : https://github.com/BerlinVagrant/vagrant-dns/issues/37
- SO : http://stackoverflow.com/questions/33037180/vagrant-manage-hosts-dhcp/33039912?noredirect=1#comment53971285_33039912
