### PR TITLE
Rubydns 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby(ENV['TEST_RUBY_VERSION'] || '~> 2.2.5')
+ruby(ENV['TEST_RUBY_VERSION'] || '~> 2.2.6')
 
 ENV['TEST_VAGRANT_VERSION'] ||= 'v1.9.3'
 
@@ -15,7 +15,7 @@ group :test, :development do
   else
     gem 'vagrant', :github => 'mitchellh/vagrant', :tag => ENV['TEST_VAGRANT_VERSION']
   end
-  gem 'rubydns', '~> 1.0.2'
+  gem 'rubydns', '~> 2.0.0.pre.rc1'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
-ruby(ENV['TEST_RUBY_VERSION'] || '~> 2.2.6')
+ruby(ENV['TEST_RUBY_VERSION'] || '~> 2.3.4')
 
-ENV['TEST_VAGRANT_VERSION'] ||= 'v1.9.3'
+ENV['TEST_VAGRANT_VERSION'] ||= 'v1.9.6'
 
 # Using the :plugins group causes Vagrant to automagially load auto_network
 # during acceptance tests.
@@ -11,11 +11,11 @@ end
 
 group :test, :development do
   if ENV['TEST_VAGRANT_VERSION'] == 'HEAD'
-    gem 'vagrant', :github => 'mitchellh/vagrant', :branch => 'master'
+    gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant', :branch => 'master'
   else
-    gem 'vagrant', :github => 'mitchellh/vagrant', :tag => ENV['TEST_VAGRANT_VERSION']
+    gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant', :tag => ENV['TEST_VAGRANT_VERSION']
   end
-  gem 'rubydns', '~> 2.0.0.pre.rc1'
+  gem 'rubydns', '~> 2.0.0.pre.rc2'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,7 @@ group :test, :development do
 end
 
 group :test do
-  # Pinned on 05/05/2014. Compatible with Vagrant 1.5.x and 1.6.x.
-  gem 'vagrant-spec', :github => 'mitchellh/vagrant-spec', :ref => 'aae28ee'
+  gem 'vagrant-spec', :git => 'https://github.com/mitchellh/vagrant-spec'
   gem 'rake'
 end
 

--- a/lib/vagrant-dns/service.rb
+++ b/lib/vagrant-dns/service.rb
@@ -25,10 +25,10 @@ module VagrantDNS
     def run!(run_options)
       Daemons.run_proc("vagrant-dns", run_options) do
         require 'rubydns'
-        require 'rubydns/system'
+        require 'async/dns/system'
 
         registry = YAML.load(File.read(config_file))
-        std_resolver = RubyDNS::Resolver.new(RubyDNS::System::nameservers)
+        std_resolver = RubyDNS::Resolver.new(Async::DNS::System.nameservers)
 
         RubyDNS::run_server(:listen => VagrantDNS::Config.listen) do
           registry.each do |pattern, ip|

--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -1,25 +1,38 @@
 namespace :acceptance do
+  def tmp_dir_path
+    @tmp_dir_path ||= ENV["VS_TEMP"] || Dir.mktmpdir('vagrant-dns-spec')
+  end
+
   ARTIFACT_DIR = File.join('test', 'acceptance', 'artifacts')
+
   TEST_BOXES = {
     :virtualbox => 'http://files.vagrantup.com/precise32.box'
   }
 
-  directory ARTIFACT_DIR
-  TEST_BOXES.each do |(provider, box_url)|
-    file File.join(ARTIFACT_DIR, "#{provider}.box") => ARTIFACT_DIR do |path|
-      puts 'Downloading: ' + box_url
-      Kernel.system 'curl', '-L', '-o', path.to_s, box_url
+  TEST_BOXES.each do |provider, box_url|
+    # Declare file download tasks
+    directory ARTIFACT_DIR do
+      file File.join(ARTIFACT_DIR, "#{provider}.box") => ARTIFACT_DIR do |path|
+        puts 'Downloading: ' + box_url
+        Kernel.system 'curl', '-L', '-o', path.to_s, box_url
+      end
     end
-  end
 
-  desc 'downloads test boxes and other artifacts'
-  task :setup => TEST_BOXES.map { |(provider, box_url)| File.join(ARTIFACT_DIR, "#{provider}.box") }
+    desc "Run acceptance tests for #{provider}"
+    task provider => :"setup:#{provider}" do |task|
+      box_path = File.expand_path(File.join('..', '..', ARTIFACT_DIR, "#{provider}.box"), __FILE__)
+      puts "TMPDIR: " + tmp_dir_path
+      Kernel.system(
+        {
+          "VS_PROVIDER" => provider.to_s,
+          "VS_BOX_PATH" => box_path,
+          "TMPDIR" => tmp_dir_path
+        },
+        "bundle", "exec", "vagrant-spec", "test"
+      )
+    end
 
-  desc 'runs acceptance tests'
-  task :run => :setup do
-    command = 'vagrant-spec test'
-    puts command
-    puts
-    exec(command)
+    desc "downloads test boxes and other artifacts for #{provider}"
+    task :"setup:#{provider}" => File.join(ARTIFACT_DIR, "#{provider}.box")
   end
 end

--- a/test/acceptance/dns/dhcp_private_spec.rb
+++ b/test/acceptance/dns/dhcp_private_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'provider/dns_dhcp_private' do |provider, options|
   end
 
   include_context 'acceptance'
-  let(:tmp_path) { environment.instance_variable_get(:@homedir) }
+  let(:tmp_path) { environment.homedir }
 
   let(:tld)    { 'spec' }
   let(:name)   { 'dhcp-private.testbox.spec' }

--- a/test/acceptance/dns/static_private_spec.rb
+++ b/test/acceptance/dns/static_private_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'provider/dns_static_private' do |provider, options|
   end
 
   include_context 'acceptance'
-  let(:tmp_path) { environment.instance_variable_get(:@homedir) }
+  let(:tmp_path) { environment.homedir }
 
   let(:box_ip) { '10.10.10.101' }
   let(:tld)    { 'spec' }

--- a/test/acceptance/dns/static_public_spec.rb
+++ b/test/acceptance/dns/static_public_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'provider/dns_static_public' do |provider, options|
   end
 
   include_context 'acceptance'
-  let(:tmp_path) { environment.instance_variable_get(:@homedir) }
+  let(:tmp_path) { environment.homedir }
 
   let(:box_ip) { '10.10.10.102' }
   let(:tld)    { 'spec' }

--- a/test/acceptance/skeletons/dns_dhcp_private/Vagrantfile
+++ b/test/acceptance/skeletons/dns_dhcp_private/Vagrantfile
@@ -5,6 +5,11 @@ Vagrant.configure("2") do |config|
   config.vm.box = "box"
   config.vm.network :private_network, type: :dhcp
 
+  # vagrant-specs will fail otherwise
+  config.vm.provider "virtualbox" do |v|
+    v.gui = true
+  end
+
   # we don't need synced_folder, also they might lead to failures due
   # to guest additions mismatches
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/test/acceptance/skeletons/dns_static_private/Vagrantfile
+++ b/test/acceptance/skeletons/dns_static_private/Vagrantfile
@@ -5,6 +5,11 @@ Vagrant.configure("2") do |config|
   config.vm.box = "box"
   config.vm.network :private_network, ip: '10.10.10.101'
 
+  # vagrant-specs will fail otherwise
+  config.vm.provider "virtualbox" do |v|
+    v.gui = true
+  end
+
   # we don't need synced_folder, also they might lead to failures due
   # to guest additions mismatches
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/test/acceptance/skeletons/dns_static_public/Vagrantfile
+++ b/test/acceptance/skeletons/dns_static_public/Vagrantfile
@@ -5,6 +5,11 @@ Vagrant.configure("2") do |config|
   config.vm.box = "box"
   config.vm.network :public_network, ip: '10.10.10.102', bridge: "en0: Wi-Fi (AirPort)"
 
+  # vagrant-specs will fail otherwise
+  config.vm.provider "virtualbox" do |v|
+    v.gui = true
+  end
+
   # we don't need synced_folder, also they might lead to failures due
   # to guest additions mismatches
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrant-dns.gemspec
+++ b/vagrant-dns.gemspec
@@ -15,8 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Vagrant::Dns::VERSION
 
+  gem.required_ruby_version = '>= 2.2.6'
+
   gem.add_dependency "daemons"
-  gem.add_dependency "rubydns", '~> 2.0.0.pre.rc1'
+  gem.add_dependency "rubydns", '~> 2.0.0.pre.rc2'
 
   gem.add_development_dependency 'rspec', '~> 2.14.0' # pin for vagrant-spec
 end

--- a/vagrant-dns.gemspec
+++ b/vagrant-dns.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Vagrant::Dns::VERSION
 
   gem.add_dependency "daemons"
-  gem.add_dependency "rubydns", '~> 1.0.2'
+  gem.add_dependency "rubydns", '~> 2.0.0.pre.rc1'
 
-  gem.add_development_dependency 'rspec', '~> 2.14.0'
+  gem.add_development_dependency 'rspec', '~> 2.14.0' # pin for vagrant-spec
 end

--- a/vagrant-spec.config.rb
+++ b/vagrant-spec.config.rb
@@ -7,9 +7,11 @@ Vagrant::Spec::Acceptance.configure do |c|
   c.component_paths = [acceptance_dir.to_s]
   c.skeleton_paths = [(acceptance_dir + 'skeletons').to_s]
 
-  c.provider 'virtualbox',
-    box: (acceptance_dir + 'artifacts' + 'virtualbox.box').to_s,
-    env_vars: {
-      'VBOX_USER_HOME' => '{{homedir}}',
-    }
+  c.provider ENV['VS_PROVIDER'],
+    box: ENV['VS_BOX_PATH'],
+    skeleton_path: c.skeleton_paths
+
+  # there seems no other way to set additional environment variables
+  # see: https://github.com/mitchellh/vagrant-spec/pull/17
+  c.instance_variable_set(:@env, c.env.merge('VBOX_USER_HOME' => "{{homedir}}"))
 end


### PR DESCRIPTION
upgrades ruby-dns to "2.0.0.pre.rc1" as suggested in #48.

In my local test, everything seems to work just fine.
There is one major issue though: The current version of vagrant (1.9.3) bundles ruby 2.2.5 and rubydns requires >= 2.2.6