### PR TITLE
Rework IP lookup to skip networkconfigs without IP

### DIFF
--- a/test/acceptance/dns/static_private_spec.rb
+++ b/test/acceptance/dns/static_private_spec.rb
@@ -1,0 +1,84 @@
+shared_examples 'provider/dns_static_private' do |provider, options|
+
+  if !File.file?(options[:box])
+    raise ArgumentError,
+      "A box file #{options[:box]} must be downloaded for provider: #{provider}. Try: rake acceptance:setup"
+  end
+
+  include_context 'acceptance'
+  let(:tmp_path) { environment.instance_variable_get(:@homedir) }
+
+  let(:box_ip) { '10.10.10.101' }
+  let(:tld)    { 'spec' }
+  let(:name)   { 'private.testbox.spec' }
+
+  before do
+    ENV['VAGRANT_DEFAULT_PROVIDER'] = provider
+    environment.skeleton('dns_static_private')
+  end
+
+  describe 'installation' do
+    it 'creates and removes resolver link' do
+      assert_execute('vagrant', 'dns', '--install', '--with-sudo')
+      assert_execute('sudo', 'test', '-f', "/etc/resolver/#{tld}")
+
+      assert_execute('vagrant', 'dns', '--uninstall', '--with-sudo')
+      assert_execute('sudo', 'test', '!', '-f', "/etc/resolver/#{tld}")
+    end
+
+    it 'creates config file' do
+      assert_execute('vagrant', 'dns', '--install', '--with-sudo')
+
+      # writes config file
+      result = execute('sudo', 'cat', "#{tmp_path}/tmp/dns/config")
+      expect(result).to exit_with(0)
+      expect(result.stdout).to include(%Q|"^.*#{name}$": #{box_ip}|)
+
+      assert_execute('vagrant', 'dns', '--uninstall', '--with-sudo')
+    end
+  end
+
+  describe 'running' do
+    before do
+      assert_execute('vagrant', 'box', 'add', 'box', options[:box])
+      assert_execute('vagrant', 'dns', '--install', '--with-sudo')
+      assert_execute('vagrant', 'up', "--provider=#{provider}")
+    end
+
+    after do
+      # Ensure any VMs that survived tests are cleaned up.
+      execute('vagrant', 'destroy', '--force', log: false)
+      assert_execute('vagrant', 'dns', '--uninstall', '--with-sudo')
+    end
+
+    it 'auto-starts the DNS daemon' do
+      assert_execute('pgrep', '-lf', 'vagrant-dns')
+    end
+
+    it 'registered as a resolver' do
+      # the output of `scutil` changes it's format over MacOS versions a bit
+      expected_output = Regexp.new(<<-TXT.gsub(/^\s*/, ''), Regexp::MULTILINE)
+        \\s*domain\\s*: #{tld}
+        \\s*nameserver\\[0\\]\\s*: 127.0.0.1
+        \\s*port\\s*: 5333
+        \\s*flags\\s*: Request A records, Request AAAA records
+        \\s*reach\\s*: Reachable,\\s?Local Address(, Directly Reachable Address)?
+      TXT
+
+      result = assert_execute('scutil', '--dns')
+      expect(result.stdout).to match(expected_output)
+    end
+
+    it 'responds to host-names' do
+      result = assert_execute('dscacheutil', '-q', 'host', '-a', 'name', "#{name}")
+      expect(result.stdout).to include("ip_address: #{box_ip}")
+
+      result = assert_execute('dscacheutil', '-q', 'host', '-a', 'name', "www.#{name}")
+      expect(result.stdout).to include("ip_address: #{box_ip}")
+
+      result = execute('dscacheutil', '-q', 'host', '-a', 'name', "notthere.#{tld}")
+      expect(result.stdout).to_not include("ip_address: #{box_ip}")
+    end
+  end
+
+end

--- a/test/acceptance/dns/static_public_spec.rb
+++ b/test/acceptance/dns/static_public_spec.rb
@@ -1,0 +1,84 @@
+shared_examples 'provider/dns_static_public' do |provider, options|
+
+  if !File.file?(options[:box])
+    raise ArgumentError,
+      "A box file #{options[:box]} must be downloaded for provider: #{provider}. Try: rake acceptance:setup"
+  end
+
+  include_context 'acceptance'
+  let(:tmp_path) { environment.instance_variable_get(:@homedir) }
+
+  let(:box_ip) { '10.10.10.102' }
+  let(:tld)    { 'spec' }
+  let(:name)   { 'public.testbox.spec' }
+
+  before do
+    ENV['VAGRANT_DEFAULT_PROVIDER'] = provider
+    environment.skeleton('dns_static_public')
+  end
+
+  describe 'installation' do
+    it 'creates and removes resolver link' do
+      assert_execute('vagrant', 'dns', '--install', '--with-sudo')
+      assert_execute('sudo', 'ls', "/etc/resolver/#{tld}")
+
+      assert_execute('vagrant', 'dns', '--uninstall', '--with-sudo')
+      assert_execute('sudo', 'test', '!', '-f', "/etc/resolver/#{tld}")
+    end
+
+    it 'creates config file' do
+      assert_execute('vagrant', 'dns', '--install', '--with-sudo')
+
+      # writes config file
+      result = execute('sudo', 'cat', "#{tmp_path}/tmp/dns/config")
+      expect(result).to exit_with(0)
+      expect(result.stdout).to include(%Q|"^.*#{name}$": #{box_ip}|)
+
+      assert_execute('vagrant', 'dns', '--uninstall', '--with-sudo')
+    end
+  end
+
+  describe 'running' do
+    before do
+      assert_execute('vagrant', 'box', 'add', 'box', options[:box])
+      assert_execute('vagrant', 'dns', '--install', '--with-sudo')
+      assert_execute('vagrant', 'up', "--provider=#{provider}")
+    end
+
+    after do
+      # Ensure any VMs that survived tests are cleaned up.
+      execute('vagrant', 'destroy', '--force', log: false)
+      assert_execute('vagrant', 'dns', '--uninstall', '--with-sudo')
+    end
+
+    it 'auto-starts the DNS daemon' do
+      assert_execute('pgrep', '-lf', 'vagrant-dns')
+    end
+
+    it 'registered as a resolver' do
+      # the output of `scutil` changes it's format over MacOS versions a bit
+      expected_output = Regexp.new(<<-TXT.gsub(/^\s*/, ''), Regexp::MULTILINE)
+        \\s*domain\\s*: #{tld}
+        \\s*nameserver\\[0\\]\\s*: 127.0.0.1
+        \\s*port\\s*: 5333
+        \\s*flags\\s*: Request A records, Request AAAA records
+        \\s*reach\\s*: Reachable,\\s?Local Address(, Directly Reachable Address)?
+      TXT
+
+      result = assert_execute('scutil', '--dns')
+      expect(result.stdout).to match(expected_output)
+    end
+
+    it 'responds to host-names' do
+      result = assert_execute('dscacheutil', '-q', 'host', '-a', 'name', "#{name}")
+      expect(result.stdout).to include("ip_address: #{box_ip}")
+
+      result = assert_execute('dscacheutil', '-q', 'host', '-a', 'name', "www.#{name}")
+      expect(result.stdout).to include("ip_address: #{box_ip}")
+
+      result = execute('dscacheutil', '-q', 'host', '-a', 'name', "notthere.#{tld}")
+      expect(result.stdout).to_not include("ip_address: #{box_ip}")
+    end
+  end
+
+end

--- a/test/acceptance/skeletons/dns_dhcp_private/Vagrantfile
+++ b/test/acceptance/skeletons/dns_dhcp_private/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "box"
+  config.vm.network :private_network, type: :dhcp
+
+  # we don't need synced_folder, also they might lead to failures due
+  # to guest additions mismatches
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.dns.tld      = 'spec'
+  config.dns.patterns = /^.*dhcp-private.testbox.spec$/
+
+  VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+end

--- a/test/acceptance/skeletons/dns_static_private/Vagrantfile
+++ b/test/acceptance/skeletons/dns_static_private/Vagrantfile
@@ -5,8 +5,12 @@ Vagrant.configure("2") do |config|
   config.vm.box = "box"
   config.vm.network :private_network, ip: '10.10.10.101'
 
+  # we don't need synced_folder, also they might lead to failures due
+  # to guest additions mismatches
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
   config.dns.tld      = 'spec'
-  config.dns.patterns = /^.*single.testbox.spec$/
+  config.dns.patterns = /^.*private.testbox.spec$/
 
   VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
 end

--- a/test/acceptance/skeletons/dns_static_public/Vagrantfile
+++ b/test/acceptance/skeletons/dns_static_public/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "box"
+  config.vm.network :public_network, ip: '10.10.10.102', bridge: "en0: Wi-Fi (AirPort)"
+
+  # we don't need synced_folder, also they might lead to failures due
+  # to guest additions mismatches
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.dns.tld      = 'spec'
+  config.dns.patterns = /^.*public.testbox.spec$/
+
+  VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+end

--- a/testdrive/Vagrantfile
+++ b/testdrive/Vagrantfile
@@ -15,6 +15,9 @@ Vagrant.configure("2") do |config|
 
   config.vm.hostname = "machine"
   config.vm.network :private_network, ip: "33.33.33.60"
+  # config.vm.network :private_network, type: :dhcp
+  # config.vm.network :public_network, ip: "192.168.178.222", bridge: "en0: Wi-Fi (AirPort)"
+  # config.vm.network :public_network, use_dhcp_assigned_default_route: true, bridge: "en0: Wi-Fi (AirPort)"
 
 
   VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5300]]


### PR DESCRIPTION
When looking for the box's IP address, networks without a known IP (like dhcp) will be skipped.
Additionally, if no "private network" configuration was found, "public network" configurations will be searched as well.

The fallback to '127.0.0.1', when no IP could be found, has been removed. Instead, a warning will shown.

ref #39 and #37