### PR TITLE
Add dhcp support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,5 +20,20 @@ bundle exec rake -D acceptance
 bundle exec rake acceptance:setup:virtualbox
 
 # Run tests
-rake acceptance:virtualbox
+bundle exec rake acceptance:virtualbox
+```
+
+### On other providers
+
+1. If it's not a default provider, add it to to `Gemfile` as a dependency and re-run `bundle install`.
+2. Add a box provider name to box URL mapping to the `TEST_BOXES` hash in `tasks/acceptance.rake`
+3. Run the `acceptance` rake task like above, replacing `virtualbox` with your provider.
+
+
+### VMware IPs
+
+VMware uses IPs from its bridges for DHCP and static private networks. Check IP and net masks using:
+
+```console
+ifconfig -X bridge | grep 'inet ' | grep -v '127.0.0.1' | awk '{ print $2 "\t" $4 }'
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ ENV['TEST_VAGRANT_VERSION'] ||= 'v2.3.4'
 # during acceptance tests.
 group :plugins do
   gemspec
+  # source "https://gems.hashicorp.com/" do
+  #   gem "vagrant-vmware-desktop"
+  # end
 end
 
 group :test, :development do

--- a/README.md
+++ b/README.md
@@ -148,32 +148,6 @@ We can use [multivm](https://www.vagrantup.com/docs/multi-machine/) configuratio
 *  Execute : `vagrant dns --install`
 *  Test via: `ping worker2.mysite.box` or `worker1.mysite.box`
 
-## DHCP
-
-When configuring your VM with a DHCP network, vagrant-dns tries to identify the guest IP using vagrants build-in `read_ip_address` capability.
-
-For more fine-grained control use the `ip` config.
-Here is an example using the VM's default way of communication and using the `hostname` command on it:
-
-```ruby
-Vagrant.configure("2") do |config|
-  # ...
-
-  # - `vm` is the vagrant virtual machine instance and can be used to communicate with it
-  # - `opts` is the vagrant-dns options hash (everything configured via `config.dns.*`)
-  config.dns.ip = -> (vm, opts) do
-    # note: the block handed to `execute` might get called multiple times, hence this closure
-    ip = nil
-    vm.communicate.execute("hostname -I | cut -d ' ' -f 1") do |type, data|
-      ip = data.strip if type == :stdout
-    end
-    ip
-  end
-end
-```
-
-__NOTES__: In order to obtain the IP in this way, the vagrant box needs to be up and running. You will get a log output (`Postponing running user provided IP script until box has started.`) when you try to run `vagrant dns`  on a non-running box.
-
 ## VM options
 
 * `vm.dns.tld`: Set the tld for the given virtual machine. No default.
@@ -222,6 +196,32 @@ By default, the Virtualbox NAT engine offers the same DNS servers to the guest t
 setting, however, the NAT engine will act as a DNS proxy 
 (see [Virtualbox docs](https://www.virtualbox.org/manual/ch09.html#nat-adv-dns)). That way, queries for your custom domains
 from inside the guest will also be handled by the DNS server run by the plugin.
+
+## DHCP / Dynamic IP
+
+When configuring your VM with a DHCP network, vagrant-dns tries to identify the guest IP using vagrants build-in `read_ip_address` capability.
+
+For more fine-grained control use the `ip` config.
+Here is an example using the VM's default way of communication and using the `hostname` command on it:
+
+```ruby
+Vagrant.configure("2") do |config|
+  # ...
+
+  # - `vm` is the vagrant virtual machine instance and can be used to communicate with it
+  # - `opts` is the vagrant-dns options hash (everything configured via `config.dns.*`)
+  config.dns.ip = -> (vm, opts) do
+    # note: the block handed to `execute` might get called multiple times, hence this closure
+    ip = nil
+    vm.communicate.execute("hostname -I | cut -d ' ' -f 1") do |type, data|
+      ip = data.strip if type == :stdout
+    end
+    ip
+  end
+end
+```
+
+__NOTES__: In order to obtain the IP in this way, the vagrant box needs to be up and running. You will get a log output (`Postponing running user provided IP script until box has started.`) when you try to run `vagrant dns`  on a non-running box.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,12 @@ __NOTES__: In order to obtain the IP in this way, the vagrant box needs to be up
 * `vm.dns.patterns`: A list of domain patterns to match. Defaults to `[/^.*{host_name}.{tld}$/]`
 * `vm.dns.ip`: Optional, overwrite of the default static IP detection. Valid values are:
   - `Proc`: A Proc which return value will get used as IP. Eg: `proc { |vm, opts| }` (See DHCP section for full sample)
-  - `Symbol`: Forces the use of the named static network. eg: `:private_network` or `:public_network`
+  - `Symbol`: Forces the use of the named static network: 
+    + `:private_network`: Use static ip of a configured private network (`config.vm.network "private_network", ip: "192.168.50.4"`)
+    + `:public_network`: Use static ip of a configured public network (`config.vm.network "public_network", ip: "192.168.0.17"`)
+    + `:dynamic`, `:dhcp`: Force reading the guest IP using vagrants build-in `read_ip_address` capability.
   - Default:
-      If there is any DHCP network, use the build-in `read_ip_address` capability.
+      If there is no network with a statically defined IP, and no `ip` override is given, use the build-in `read_ip_address` capability.
       Else, check `:private_network`, if none found check `:public_network`
 
 ## Global Options

--- a/lib/vagrant-dns/config.rb
+++ b/lib/vagrant-dns/config.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require "logger"
 
 module VagrantDNS
   class Config < Vagrant.plugin(2, :config)
@@ -37,7 +37,7 @@ module VagrantDNS
         failed_tlds = vm.config.dns.tlds.select { |tld| list.find(tld, default: false) }
 
         err = if failed_tlds.any?
-          "tlds include a public suffix: #{failed_tlds.join(', ')}"
+          "tlds include a public suffix: #{failed_tlds.join(", ")}"
         end
 
         if err && check_public_suffix.to_s == "error"
@@ -50,7 +50,7 @@ module VagrantDNS
       end
     end
 
-    attr_accessor :records
+    attr_accessor :records, :ip
     attr_reader :tlds, :patterns
 
     def pattern=(pattern)
@@ -68,11 +68,7 @@ module VagrantDNS
 
     # explicit hash, to get symbols in hash keys
     def to_hash
-      {
-        :patterns => patterns,
-        :records => records,
-        :tlds => tlds
-      }
+      { patterns: patterns, records: records, tlds: tlds, ip: ip }
     end
 
     def validate(machine)
@@ -96,4 +92,3 @@ module VagrantDNS
     end
   end
 end
-

--- a/lib/vagrant-dns/configurator.rb
+++ b/lib/vagrant-dns/configurator.rb
@@ -120,7 +120,7 @@ module VagrantDNS
     private def vm_ip(opts)
       user_ip = opts[:ip]
 
-      if !user_ip && has_dhcp_network?(opts) || [:dynamic, :dhcp].include?(user_ip)
+      if !user_ip && dynamic_ip_network?(opts) || [:dynamic, :dhcp].include?(user_ip)
         user_ip = DYNAMIC_VM_IP
       end
 
@@ -169,10 +169,8 @@ module VagrantDNS
       ip
     end
 
-    private def has_dhcp_network?(opts)
-      opts[:networks].any? { |(nw_type, nw_config)|
-        nw_config[:type] == :dhcp && (nw_type == :private_network || nw_type == :public_network)
-      }
+    private def dynamic_ip_network?(opts)
+      opts[:networks].none? { |(_nw_type, nw_config)| nw_config[:ip] }
     end
 
     # tries to find an IP in the configured +type+ networks

--- a/lib/vagrant-dns/configurator.rb
+++ b/lib/vagrant-dns/configurator.rb
@@ -20,164 +20,180 @@ module VagrantDNS
       unregister_patterns!
     end
 
-    private
+    private def validate_tlds
+      valid, err = VagrantDNS::Config.validate_tlds(vm)
+      if !valid
+        vm.ui.error(err)
+      elsif err
+        vm.ui.warn(err)
+      end
+      valid
+    end
 
-      def validate_tlds
-        valid, err = VagrantDNS::Config.validate_tlds(vm)
-        if !valid
-          vm.ui.error(err)
-        elsif err
-          vm.ui.warn(err)
+    private def regenerate_resolvers!
+      resolver_folder = self.resolver_folder
+      _proto, ip, port = VagrantDNS::Config.listen.first
+      tlds = register_tlds!
+
+      resolver_files(ip, port, tlds) do |filename, contents|
+        File.write(File.join(resolver_folder, filename), contents)
+      end
+    end
+
+    private def register_tlds!
+      add_tlds = dns_options(vm)[:tlds]
+      VagrantDNS::TldRegistry
+        .new(tmp_path)
+        .transaction do |store|
+          store["tlds"] ||= []
+          store["tlds"] |= add_tlds
+          store["tlds"]
         end
-        valid
+    end
+
+    private def register_patterns!
+      opts = dns_options(vm)
+
+      patterns = opts[:patterns] || default_patterns(opts)
+      if patterns.empty?
+        vm.ui.warn "[vagrant-dns] TLD but no host_name given. No patterns will be configured."
+        return
       end
 
-      def regenerate_resolvers!
-        resolver_folder = self.resolver_folder
-        _proto, ip, port = VagrantDNS::Config.listen.first
-        tlds = register_tlds!
-
-        resolver_files(ip, port, tlds) do |filename, contents|
-          File.write(File.join(resolver_folder, filename), contents)
-        end
+      ip = vm_ip(opts)
+      unless ip
+        vm.ui.detail "[vagrant-dns] No patterns will be configured."
+        return
       end
 
-      def register_tlds!
-        add_tlds = dns_options(vm)[:tlds]
-        VagrantDNS::TldRegistry
-          .new(tmp_path)
-          .transaction do |store|
-            store["tlds"] ||= []
-            store["tlds"] |= add_tlds
-            store["tlds"]
-          end
+      registry = Registry.new(tmp_path)
+      registry.transaction do
+        patterns.each { |pattern| registry[pattern] = ip }
+      end
+    end
+
+    private def unregister_patterns!
+      opts = dns_options(vm)
+
+      patterns = opts[:patterns] || default_patterns(opts)
+      if patterns.empty?
+        vm.ui.warn "[vagrant-dns] TLD but no host_name given. No patterns will be removed."
+        return
       end
 
-      def register_patterns!
-        opts = dns_options(vm)
+      registry = Registry.open(tmp_path)
+      return unless registry
 
-        patterns = opts[:patterns] || default_patterns(opts)
-        if patterns.empty?
-          vm.ui.warn "[vagrant-dns] TLD but no host_name given. No patterns will be configured."
-          return
+      registry.transaction do
+        unless registry.any?
+          vm.ui.warn "[vagrant-dns] Configuration missing or empty. No patterns will be removed."
+          registry.abort
         end
 
-        ip = vm_ip(opts)
-        unless ip
-          vm.ui.detail "[vagrant-dns] No patterns will be configured."
-          return
-        end
-
-        registry = Registry.new(tmp_path)
-        registry.transaction do
-          patterns.each { |pattern| registry[pattern] = ip }
-        end
-      end
-
-      def unregister_patterns!
-        opts = dns_options(vm)
-
-        patterns = opts[:patterns] || default_patterns(opts)
-        if patterns.empty?
-          vm.ui.warn "[vagrant-dns] TLD but no host_name given. No patterns will be removed."
-          return
-        end
-
-        registry = Registry.open(tmp_path)
-        return unless registry
-
-        registry.transaction do
-          unless registry.any?
-            vm.ui.warn "[vagrant-dns] Configuration missing or empty. No patterns will be removed."
-            registry.abort
-          end
-
-          patterns.each do |pattern|
-            if (ip = registry.delete(pattern))
-              vm.ui.info "[vagrant-dns] Removing pattern: #{pattern} for ip: #{ip}"
-            else
-              vm.ui.info "[vagrant-dns] Pattern: #{pattern} was not in config."
-            end
-          end
-        end
-      end
-
-      def dns_options(vm)
-        return @dns_options if @dns_options
-
-        @dns_options = vm.config.dns.to_hash
-        @dns_options[:host_name] = vm.config.vm.hostname
-        @dns_options[:networks] = vm.config.vm.networks
-        @dns_options
-      end
-
-      def default_patterns(opts)
-        if opts[:host_name]
-          opts[:tlds].map { |tld| /^.*#{opts[:host_name]}.#{tld}$/ }
-        else
-          []
-        end
-      end
-
-      def vm_ip(opts)
-        user_ip = opts[:ip]
-
-        ip =
-          case user_ip
-          when Proc
-            if vm.communicate.ready?
-              user_ip.call(vm, opts.dup.freeze)
-            else
-              vm.ui.info "[vagrant-dns] Postponing running user provided IP script until box has started."
-              return
-            end
-          when Symbol
-            _ip = static_vm_ip(user_ip, opts)
-
-            unless _ip
-              vm.ui.warn "[vagrant-dns] Could not find any static network IP in network type `#{user_ip}'."
-              return
-            end
-
-            _ip
+        patterns.each do |pattern|
+          if (ip = registry.delete(pattern))
+            vm.ui.info "[vagrant-dns] Removing pattern: #{pattern} for ip: #{ip}"
           else
-            _ip = static_vm_ip(:private_network, opts)
-            _ip ||= static_vm_ip(:public_network, opts)
+            vm.ui.info "[vagrant-dns] Pattern: #{pattern} was not in config."
+          end
+        end
+      end
+    end
 
-            unless _ip
-              vm.ui.warn "[vagrant-dns] Could not find any static network IP."
-              return
+    private def dns_options(vm)
+      return @dns_options if @dns_options
+
+      @dns_options = vm.config.dns.to_hash
+      @dns_options[:host_name] = vm.config.vm.hostname
+      @dns_options[:networks] = vm.config.vm.networks
+      @dns_options
+    end
+
+    private def default_patterns(opts)
+      if opts[:host_name]
+        opts[:tlds].map { |tld| /^.*#{opts[:host_name]}.#{tld}$/ }
+      else
+        []
+      end
+    end
+
+    private def vm_ip(opts)
+      user_ip = opts[:ip]
+
+      if !user_ip && has_dhcp_network?(opts)
+        user_ip = proc { |vm|
+          vm.guest.capability(:read_ip_address).tap { |ip|
+            if ip
+              vm.ui.info "[vagrant-dns] Identified DHCP IP as '#{ip}'."
+            else
+              vm.ui.warn "[vagrant-dns] Could not identify DHCP IP."
             end
+          }
+        }
+      end
 
-            _ip
+      ip =
+        case user_ip
+        when Proc
+          if vm.communicate.ready?
+            user_ip.call(vm, opts.dup.freeze)
+          else
+            vm.ui.info "[vagrant-dns] Postponing running user provided IP script until box has started."
+            return
+          end
+        when Symbol
+          _ip = static_vm_ip(user_ip, opts)
+
+          unless _ip
+            vm.ui.warn "[vagrant-dns] Could not find any static network IP in network type `#{user_ip}'."
+            return
           end
 
-        if !ip || ip.empty?
-          vm.ui.warn "[vagrant-dns] Failed to identify IP."
-          return
+          _ip
+        else
+          _ip = static_vm_ip(:private_network, opts)
+          _ip ||= static_vm_ip(:public_network, opts)
+
+          unless _ip
+            vm.ui.warn "[vagrant-dns] Could not find any static network IP."
+            return
+          end
+
+          _ip
         end
 
-        ip
+      if !ip || ip.empty?
+        vm.ui.warn "[vagrant-dns] Failed to identify IP."
+        return
       end
 
-      # tries to find an IP in the configured +type+ networks
-      def static_vm_ip(type, opts)
-        network = opts[:networks].find { |nw| nw.first == type && nw.last[:ip] }
+      ip
+    end
 
-        network.last[:ip] if network
-      end
+    private def has_dhcp_network?(opts)
+      opts[:networks].any? { |(nw_type, nw_config)|
+        nw_config[:type] == :dhcp && (nw_type == :private_network || nw_type == :public_network)
+      }
+    end
 
-      def resolver_files(ip, port, tlds, &block)
-        installer_class = VagrantDNS::Installers.resolve
-        installer_class.resolver_files(ip, port, tlds, &block)
-      end
+    # tries to find an IP in the configured +type+ networks
+    private def static_vm_ip(type, opts)
+      network = opts[:networks].find { |(nw_type, nw_config)| nw_config[:ip] && nw_type == type }
 
-      def resolver_folder
-        File.join(tmp_path, "resolver").tap { |dir| FileUtils.mkdir_p(dir) }
-      end
+      network.last[:ip] if network
+    end
 
-      def ensure_deamon_env!
-        FileUtils.mkdir_p(File.join(tmp_path, "daemon"))
-      end
+    private def resolver_files(ip, port, tlds, &block)
+      installer_class = VagrantDNS::Installers.resolve
+      installer_class.resolver_files(ip, port, tlds, &block)
+    end
+
+    private def resolver_folder
+      File.join(tmp_path, "resolver").tap { |dir| FileUtils.mkdir_p(dir) }
+    end
+
+    private def ensure_deamon_env!
+      FileUtils.mkdir_p(File.join(tmp_path, "daemon"))
+    end
   end
 end

--- a/lib/vagrant-dns/service.rb
+++ b/lib/vagrant-dns/service.rb
@@ -92,9 +92,7 @@ module VagrantDNS
       end
     end
 
-    private
-
-    def run_options(cmd, extra = {})
+    private def run_options(cmd, extra = {})
       daemon_dir = File.join(tmp_path, "daemon")
       {
         ARGV: [cmd],
@@ -103,7 +101,7 @@ module VagrantDNS
         log_output: true,
         log_dir: daemon_dir,
         **extra
-     }
+      }
     end
   end
 end

--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -11,7 +11,9 @@ namespace :acceptance do
     # Ubuntu 16.04 https://app.vagrantup.com/ubuntu/boxes/xenial64.json
     # :virtualbox => "https://vagrantcloud.com/ubuntu/boxes/xenial64/versions/20180511.0.0/providers/virtualbox.box"
     # Ubuntu 18.04 https://app.vagrantup.com/ubuntu/boxes/bionic64.json
-    :virtualbox => "https://vagrantcloud.com/ubuntu/boxes/bionic64/versions/20180709.0.0/providers/virtualbox.box"
+    virtualbox: "https://vagrantcloud.com/ubuntu/boxes/bionic64/versions/20180709.0.0/providers/virtualbox.box",
+    # Ubuntu 22.10 https://app.vagrantup.com/bento/boxes/ubuntu-22.10
+    vmware_desktop: "https://app.vagrantup.com/bento/boxes/ubuntu-22.10/versions/202303.13.0/providers/vmware_desktop.box"
   }
 
   TEST_BOXES.each do |provider, box_url|

--- a/test/acceptance/dns/public_suffix_spec.rb
+++ b/test/acceptance/dns/public_suffix_spec.rb
@@ -1,7 +1,6 @@
-require "pp"
 shared_examples 'provider/tld_public_suffix' do |provider, options|
 
-  if !File.file?(options[:box])
+  if options[:box] && !File.file?(options[:box])
     raise ArgumentError,
       "A box file #{options[:box]} must be downloaded for provider: #{provider}. Try: rake acceptance:setup"
   end

--- a/test/acceptance/dns/static_private_spec.rb
+++ b/test/acceptance/dns/static_private_spec.rb
@@ -1,6 +1,6 @@
 shared_examples 'provider/dns_static_private' do |provider, options|
 
-  if !File.file?(options[:box])
+  if options[:box] && !File.file?(options[:box])
     raise ArgumentError,
       "A box file #{options[:box]} must be downloaded for provider: #{provider}. Try: rake acceptance:setup"
   end
@@ -8,7 +8,12 @@ shared_examples 'provider/dns_static_private' do |provider, options|
   include_context 'acceptance'
   let(:tmp_path) { environment.homedir }
 
-  let(:box_ip) { '10.10.10.101' }
+  let(:box_ip) do
+    case provider
+    when "virtualbox" then '10.10.10.101'
+    when "vmware_desktop" then '192.168.134.111'
+    end
+  end
   let(:tld)    { 'spec' }
   let(:name)   { 'private.testbox.spec' }
 
@@ -114,7 +119,7 @@ shared_examples 'provider/dns_static_private' do |provider, options|
       result = assert_execute('vagrant', 'dns', '--list')
       expect(result.stdout).to_not include(name)
       expect(result.stdout).to_not include(box_ip)
-      expect(result.stdout).to include("Configuration missing or empty.")
+      expect(result.stdout).to include("Pattern configuration missing or empty.")
     end
   end
 end

--- a/test/acceptance/dns/static_public_spec.rb
+++ b/test/acceptance/dns/static_public_spec.rb
@@ -1,6 +1,6 @@
 shared_examples 'provider/dns_static_public' do |provider, options|
 
-  if !File.file?(options[:box])
+  if options[:box] && !File.file?(options[:box])
     raise ArgumentError,
       "A box file #{options[:box]} must be downloaded for provider: #{provider}. Try: rake acceptance:setup"
   end
@@ -114,7 +114,7 @@ shared_examples 'provider/dns_static_public' do |provider, options|
       result = assert_execute('vagrant', 'dns', '--list')
       expect(result.stdout).to_not include(name)
       expect(result.stdout).to_not include(box_ip)
-      expect(result.stdout).to include("Configuration missing or empty.")
+      expect(result.stdout).to include("Pattern configuration missing or empty.")
     end
   end
 end

--- a/test/acceptance/skeletons/dns_dhcp_private/Vagrantfile
+++ b/test/acceptance/skeletons/dns_dhcp_private/Vagrantfile
@@ -17,5 +17,5 @@ Vagrant.configure("2") do |config|
   config.dns.tld      = 'spec'
   config.dns.patterns = /^.*dhcp-private.testbox.spec$/
 
-  VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+  VagrantDNS::Config.listen = [[:udp, "127.0.0.1", 5333]]
 end

--- a/test/acceptance/skeletons/dns_dhcp_private_callback/Vagrantfile
+++ b/test/acceptance/skeletons/dns_dhcp_private_callback/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |global_config|
+  global_config.vm.define :plain_dhcp do |config|
+
+    config.vm.box = "box"
+    config.vm.network :private_network, type: :dhcp
+
+    # we don't need synced_folder, also they might lead to failures due
+    # to guest additions mismatches
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+
+    config.dns.tld      = 'spec'
+    config.dns.patterns = /^.*plain-dhcp-private.testbox.spec$/
+    config.dns.ip       = -> (vm, opts) do
+      ip = nil
+      vm.communicate.execute("hostname -I") { |type, data| ip = data.split.last if type == :stdout }
+      ip
+    end
+
+
+    VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+  end
+end

--- a/test/acceptance/skeletons/dns_dhcp_private_callback/Vagrantfile
+++ b/test/acceptance/skeletons/dns_dhcp_private_callback/Vagrantfile
@@ -19,7 +19,6 @@ Vagrant.configure("2") do |global_config|
       ip
     end
 
-
-    VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+    VagrantDNS::Config.listen = [[:udp, "127.0.0.1", 5333]]
   end
 end

--- a/test/acceptance/skeletons/dns_static_private/Vagrantfile
+++ b/test/acceptance/skeletons/dns_static_private/Vagrantfile
@@ -3,11 +3,19 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "box"
-  config.vm.network :private_network, ip: '10.10.10.101'
+
+  # skip custom subnet and mask by default, add for virtualbox
+  # https://developer.hashicorp.com/vagrant/docs/providers/vmware/known-issues#creating-network-devices
+  config.vm.network :private_network
 
   # vagrant-specs will fail otherwise
-  config.vm.provider "virtualbox" do |v|
+  config.vm.provider "virtualbox" do |v, override|
+    override.vm.network :private_network, ip: '10.10.10.101'
     v.gui = true
+  end
+
+  config.vm.provider "vmware_desktop" do |v, override|
+    override.vm.network :private_network, ip: '192.168.134.111'
   end
 
   # we don't need synced_folder, also they might lead to failures due
@@ -17,5 +25,5 @@ Vagrant.configure("2") do |config|
   config.dns.tld      = 'spec'
   config.dns.patterns = /^.*private.testbox.spec$/
 
-  VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+  VagrantDNS::Config.listen = [[:udp, "127.0.0.1", 5333]]
 end

--- a/test/acceptance/skeletons/dns_static_public/Vagrantfile
+++ b/test/acceptance/skeletons/dns_static_public/Vagrantfile
@@ -17,5 +17,5 @@ Vagrant.configure("2") do |config|
   config.dns.tld      = 'spec'
   config.dns.patterns = /^.*public.testbox.spec$/
 
-  VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+  VagrantDNS::Config.listen = [[:udp, "127.0.0.1", 5333]]
 end

--- a/test/acceptance/skeletons/tld_public_suffix/Vagrantfile
+++ b/test/acceptance/skeletons/tld_public_suffix/Vagrantfile
@@ -18,5 +18,5 @@ Vagrant.configure("2") do |config|
   config.dns.patterns = /^.*public.testbox.com$/
   #---VagrantDNS::Config.check_public_suffix---#
 
-  VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5333]]
+  VagrantDNS::Config.listen = [[:udp, "127.0.0.1", 5333]]
 end

--- a/testdrive/Vagrantfile
+++ b/testdrive/Vagrantfile
@@ -7,7 +7,8 @@ Vagrant.configure("2") do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box     = 'hashicorp/bionic64'
+  # config.vm.box     = 'hashicorp/bionic64'
+  config.vm.box     = "bento/ubuntu-22.10"
   # config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
@@ -28,6 +29,6 @@ Vagrant.configure("2") do |config|
   #   ip
   # end
 
-  VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5300]]
+  VagrantDNS::Config.listen = [[:udp, "127.0.0.1", 5300]]
   VagrantDNS::Config.ttl = 30
 end

--- a/testdrive/Vagrantfile
+++ b/testdrive/Vagrantfile
@@ -7,8 +7,8 @@ Vagrant.configure("2") do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box     = 'precise32'
-  config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
+  config.vm.box     = 'hashicorp/bionic64'
+  # config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
@@ -20,13 +20,13 @@ Vagrant.configure("2") do |config|
 
   config.dns.tld      = "test"
   config.dns.patterns = /^.*machine.test$/
-  config.dns.ip       = -> (vm, opts) do
-    ip = nil
-    vm.communicate.execute("hostname -I") do |type, data|
-      ip = data.split[1] if type == :stdout
-    end
-    ip
-  end
+  # config.dns.ip = -> (vm, opts) do
+  #   ip = nil
+  #   vm.communicate.execute("hostname -I | cut -d ' ' -f 1") do |type, data|
+  #     ip = data.strip if type == :stdout
+  #   end
+  #   ip
+  # end
 
   VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5300]]
   VagrantDNS::Config.ttl = 30

--- a/testdrive/Vagrantfile
+++ b/testdrive/Vagrantfile
@@ -10,8 +10,7 @@ Vagrant.configure("2") do |config|
   config.vm.box     = 'precise32'
   config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
 
-  config.dns.tld      = "test"
-  config.dns.patterns = /^.*machine.test$/
+  config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.hostname = "machine"
   # config.vm.network :private_network, ip: "33.33.33.60"
@@ -19,8 +18,15 @@ Vagrant.configure("2") do |config|
   # config.vm.network :public_network, ip: "192.168.178.222", bridge: "en0: Wi-Fi (AirPort)"
   # config.vm.network :public_network, use_dhcp_assigned_default_route: true, bridge: "en0: Wi-Fi (AirPort)"
 
-
-  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.dns.tld      = "test"
+  config.dns.patterns = /^.*machine.test$/
+  config.dns.ip       = -> (vm, opts) do
+    ip = nil
+    vm.communicate.execute("hostname -I") do |type, data|
+      ip = data.split[1] if type == :stdout
+    end
+    ip
+  end
 
   VagrantDNS::Config.listen = [[:udp, "0.0.0.0", 5300]]
   VagrantDNS::Config.ttl = 30

--- a/vagrant-spec.config.rb
+++ b/vagrant-spec.config.rb
@@ -7,9 +7,7 @@ Vagrant::Spec::Acceptance.configure do |c|
   c.component_paths = [acceptance_dir.to_s]
   c.skeleton_paths = [(acceptance_dir + 'skeletons').to_s]
 
-  c.provider ENV['VS_PROVIDER'],
-    box: ENV['VS_BOX_PATH'],
-    skeleton_path: c.skeleton_paths
+  c.provider ENV['VS_PROVIDER'], box: ENV['VS_BOX_PATH'], skeleton_path: c.skeleton_paths
 
   # there seems no other way to set additional environment variables
   # see: https://github.com/mitchellh/vagrant-spec/pull/17


### PR DESCRIPTION
open issue: The `restart_host_dns` action hook needs to get moved after provider specific actions (so that the host network had a chance to get configured).
see mitchellh/vagrant#8500