### PR TITLE
workaround for vagrant plugin install issue

### DIFF
--- a/vagrant-dns.gemspec
+++ b/vagrant-dns.gemspec
@@ -22,5 +22,10 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rubydns", '~> 2.0.0'
   gem.add_dependency "public_suffix"
 
+  # Pinning async gem to work around an issue in vagrant, where it does not
+  # honor "required_ruby_version" while resolving sub-dependencies.
+  # see: https://github.com/hashicorp/vagrant/issues/12640
+  gem.add_dependency 'async', '< 2'
+
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
... trying to install newer io-event which requires ruby 3.0

closed #69 