### PR TITLE
Bump rubydns and async-dns requirements, fix for change made in async-dns 1.4.0

### DIFF
--- a/lib/vagrant-dns/server.rb
+++ b/lib/vagrant-dns/server.rb
@@ -12,7 +12,7 @@ module VagrantDNS
       @ttl = ttl
 
       @resolver = if resolver.nil? || resolver == :system
-        RubyDNS::Resolver.new(Async::DNS::System.nameservers)
+        Async::DNS::Resolver.default
       elsif !resolver || resolver.empty?
         nil
       else

--- a/vagrant-dns.gemspec
+++ b/vagrant-dns.gemspec
@@ -26,13 +26,14 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2.6'
 
   gem.add_dependency "daemons"
-  gem.add_dependency "rubydns", '~> 2.0.0'
+  gem.add_dependency "rubydns", '~> 2.1'
   gem.add_dependency "public_suffix"
 
   # Pinning async gem to work around an issue in vagrant, where it does not
   # honor "required_ruby_version" while resolving sub-dependencies.
   # see: https://github.com/hashicorp/vagrant/issues/12640
   gem.add_dependency 'async', '~> 1.30', '>= 1.30.3'
+  gem.add_dependency 'async-dns', '~> 1.4'
 
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Here is what I believe to be a fix for #85.

The `Async::DNS::System.nameservers` method has been removed in https://github.com/socketry/async-dns/commit/9599751785c91409b2f8a1f76027493e511f2e97.

According to the [changelog](https://github.com/socketry/async-dns/blob/main/readme.md#v140),

> Async::DNS::Resolver.default should be used to get a default resolver instance.

With that change alone, the server still failed to start. I think the way how `VagrantDNS::Server::run` calls `RubyDNS::run_server` only works with [this change](https://github.com/socketry/rubydns/commit/4c2bb113c6af2fd230bb716111010cb2aa389013#diff-21e5cca57be97c15b0959d955a45666d6fee4e200e52269341c239c8bd696675R30), so I bumped the `rubydns` requirement to 2.1.0 as well.

This has been "coded" by trial and error, since I have no Ruby experience at all. Hope it makes sense 🤞🏻