### PR TITLE
Pin async-dns to < 1.4 to avoid breaking changes in its API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2 (unreleased)
+
+* Pin async-dns to < 1.4 to avoid breaking changes in its API. [GH-85]
+
 ## 2.4.1 (2023-04-16)
 
 * Fix plugin hooking for multi-machine setups. [GH-78]

--- a/vagrant-dns.gemspec
+++ b/vagrant-dns.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "daemons"
   gem.add_dependency "rubydns", '~> 2.0.0'
+  gem.add_dependency "async-dns", '< 1.4.0'
   gem.add_dependency "public_suffix"
 
   # Pinning async gem to work around an issue in vagrant, where it does not


### PR DESCRIPTION
see https://github.com/BerlinVagrant/vagrant-dns/pull/86#issuecomment-2677914722